### PR TITLE
[DO NOT MERGE]: Move conformance workflow to `pull_request_target` trigger

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
I'm doing some testing to figure out what identity gets used when we run on the `pull_request_target` trigger.